### PR TITLE
Upgrade micronaut-rethrow to Micronaut 5.x

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,14 +23,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
-      - uses: gradle/gradle-build-action@v2
-        with:
-          arguments: check coveralls
+      - uses: gradle/actions/setup-gradle@v5
+      - run: ./gradlew check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
       - name: Semantic Version
         id: version
@@ -28,12 +22,20 @@ jobs:
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
+      - uses: gradle/actions/setup-gradle@v5
       - name: Release
         env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        uses: eskatos/gradle-command-action@v2
-        with:
-          arguments: gitPublishPush publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: |
+          ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
+            -Pversion=${{ steps.version.outputs.tag }} \
+            -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
+            -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
+            -Prelease=true \
+            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }} \
+            --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
@@ -46,7 +48,7 @@ jobs:
           # - agorapulse/agorapulse-bom
           - agorapulse/agorapulse-oss
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1
@@ -56,4 +58,4 @@ jobs:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-rethrow", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.rethrow.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-rethrow", "micronautCompatibility": [5], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.rethrow.version", "github" : ${{ toJson(github) }} }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           arguments: gitPublishPush publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
   ping:
+    if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
     needs: [release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,7 @@ jobs:
     strategy:
       matrix:
         repository:
-          # until all projects are migrated to Micronaut 4.x
-          # - agorapulse/agorapulse-bom
+          - agorapulse/agorapulse-bom
           - agorapulse/agorapulse-oss
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://github.com/agorapulse/micronaut-rethrow/workflows/Check/badge.svg)](https://github.com/agorapulse/micronaut-rethrow/actions)
 [![Maven Central](https://img.shields.io/maven-central/v/com.agorapulse/micronaut-rethrow.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.agorapulse%22%20AND%20a:%22micronaut-rethrow%22)
-[![Coverage Status](https://coveralls.io/repos/github/agorapulse/micronaut-rethrow/badge.svg?branch=master)](https://coveralls.io/github/agorapulse/micronaut-rethrow?branch=master)
 
 Micronaut Rethrow Library
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2023 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,178 +16,28 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.groovy-project'
-    id 'org.kordamp.gradle.checkstyle'
-    id 'org.kordamp.gradle.codenarc'
-    id 'org.kordamp.gradle.coveralls'
-    id 'io.github.gradle-nexus.publish-plugin'
-}
-
-if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('ossrhPassword'))      ext.ossrhPassword       = System.getenv('SONATYPE_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingKeyId'))       ext.signingKeyId        = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingPassword'))    ext.signingPassword     = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingSecretKey'))   ext.signingSecretKey    = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
-
-config {
-    release = (rootProject.findProperty('release') ?: false).toBoolean()
-
-    info {
-        name        = 'Micronaut Rethrow'
-        vendor      = 'Agorapulse'
-        description = 'Micronaut Rethrow Library'
-
-        links {
-            website      = "https://github.com/" + slug
-            issueTracker = "https://github.com/" + slug + "/issues"
-            scm          = "https://github.com/" + slug + ".git"
-        }
-
-        people {
-            person {
-                id    = 'musketyr'
-                name  = 'Vladimir Orany'
-                roles = ['developer']
-            }
-        }
-
-        repositories {
-            repository {
-                name = 'localRelease'
-                url  = "" + project.rootProject.buildDir + "/repos/local/release"
-            }
-            repository {
-                name = 'localSnapshot'
-                url  = "" + project.rootProject.buildDir + "/repos/local/snapshot"
-            }
-        }
-    }
-
-    licensing {
-        licenses {
-            license {
-                id = 'Apache-2.0'
-            }
-        }
-    }
-
-    publishing {
-        enabled = false
-        signing {
-            enabled = true
-            keyId = signingKeyId
-            secretKey = signingSecretKey
-            password = signingPassword
-        }
-        releasesRepository  = 'localRelease'
-        snapshotsRepository = 'localSnapshot'
-    }
-
-    quality {
-        checkstyle {
-            toolVersion = '8.27'
-        }
-
-        codenarc {
-            toolVersion = '1.5'
-        }
-    }
-
-    docs {
-        javadoc {
-            autoLinks {
-                enabled = false
-            }
-            aggregate {
-                enabled = false
-            }
-        }
-        groovydoc {
-            enabled = false
-            aggregate {
-                enabled = false
-            }
-        }
-    }
-
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri('https://s01.oss.sonatype.org/service/local/')
-            snapshotRepositoryUrl = uri('https://s01.oss.sonatype.org/content/repositories/snapshots/')
-            username = ossrhUsername
-            password = ossrhPassword
-        }
-    }
+    id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
+    id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
 allprojects {
     repositories {
         mavenCentral()
     }
-
-    license {
-        exclude '**/*.json'
-        exclude '***.yml'
-    }
 }
 
-gradleProjects {
-    subprojects {
-        dirs(['libs']) { Project subproject ->
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(17)
-                }
-            }
-
-            repositories {
-                mavenCentral()
-            }
-
-            // location independent tests (useful for stable CI builds)
-            tasks.withType(Test) {
-                useJUnitPlatform()
-
-                systemProperty 'user.timezone', 'UTC'
-                systemProperty 'user.language', 'en'
-            }
-
-            tasks.withType(JavaCompile) {
-                options.encoding = "UTF-8"
-                options.compilerArgs.add('-parameters')
-            }
-
-            tasks.withType(GroovyCompile) {
-                groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
-            }
-
-            // useful for IntelliJ
-            task cleanOut(type: Delete) {
-                delete file('out')
-            }
-
-            clean.dependsOn cleanOut
-            processResources {
-                filesMatching('**/org.codehaus.groovy.runtime.ExtensionModule') {
-                    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [VERSION: version])
-                }
-            }
-
-            jar {
-                manifest.attributes provider: 'gradle'
-            }
-
-            config {
-                publishing {
-                    enabled = true
-                }
+subprojects {
+    plugins.withId('com.agorapulse.gradle.micronaut-library') {
+        micronaut {
+            importMicronautPlatform = true
+            testRuntime 'spock'
+            processing {
+                incremental false
             }
         }
     }
 }
 
-
-check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')
+tasks.named('check') {
+    dependsOn 'aggregateTestReports', 'aggregateJacocoReports'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,6 @@
  */
 plugins {
     id 'lifecycle-base'
-    id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
-    id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
 if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
@@ -81,8 +79,4 @@ subprojects {
             sign publishing.publications
         }
     }
-}
-
-tasks.named('check') {
-    dependsOn 'aggregateTestReports', 'aggregateJacocoReports'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ plugins {
     id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword       = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId       = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey         = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
+
 allprojects {
     repositories {
         mavenCentral()
@@ -34,6 +40,44 @@ subprojects {
             processing {
                 incremental false
             }
+        }
+    }
+
+    plugins.withId('com.vanniktech.maven.publish') {
+        mavenPublishing {
+            publishToMavenCentral(true)
+            signAllPublications()
+
+            pom {
+                name = 'Micronaut Rethrow'
+                description = 'Rethrow checked exceptions as runtime exceptions in Micronaut applications.'
+                inceptionYear = '2019'
+                url = "https://github.com/${slug}"
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'musketyr'
+                        name = 'Vladimir Orany'
+                        url = 'https://github.com/musketyr/'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${slug}.git"
+                    connection = "scm:git:git://github.com/${slug}.git"
+                    developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                }
+            }
+        }
+
+        signing {
+            useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+            sign publishing.publications
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 plugins {
+    id 'lifecycle-base'
     id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
     id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2023 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,10 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.guide'
-    id 'org.ajoberstar.git-publish'
-}
-
-config {
-    docs {
-        guide {
-            publish {
-                enabled = true
-            }
-        }
-    }
-}
-
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
+    id 'com.agorapulse.gradle.guide'
 }
 
 asciidoctor {
-    configurations 'asciidoctorExtensions'
-
     baseDirFollowsSourceDir()
 
     attributes = [
@@ -49,5 +28,4 @@ asciidoctor {
         'root-dir': rootDir,
         'project-slug': slug
     ]
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ javaVersion = 25
 
 agorapulseGradlePluginsVersion = 4.4.2
 agorapulseAggregateReportsVersion = 4.0.0-rc3
-nexusPluginVersion=1.0.0
+mavenCentralPublishPluginVersion = 0.34.0
 gitPublishPluginVersion=2.1.3
 
 micronautVersion = 4.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,10 +16,16 @@
 # limitations under the License.
 #
 
+org.gradle.caching=true
+
 slug=agorapulse/micronaut-rethrow
 group=com.agorapulse
 version=3.0.0-SNAPSHOT
-kordampPluginVersion=0.51.0
+
+javaVersion = 25
+
+agorapulseGradlePluginsVersion = 4.4.2
+agorapulseAggregateReportsVersion = 4.0.0-rc3
 nexusPluginVersion=1.0.0
 gitPublishPluginVersion=2.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ version=3.0.0-SNAPSHOT
 javaVersion = 25
 
 agorapulseGradlePluginsVersion = 4.4.2
-agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ javaVersion = 25
 agorapulseGradlePluginsVersion = 4.4.2
 agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
+develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
 micronautVersion = 5.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,5 +29,5 @@ agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
 gitPublishPluginVersion=2.1.3
 
-micronautVersion = 4.2.0
-micronautGradlePluginVersion = 4.2.0
+micronautVersion = 5.0.0
+micronautGradlePluginVersion = 5.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/micronaut-rethrow/micronaut-rethrow.gradle
+++ b/libs/micronaut-rethrow/micronaut-rethrow.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2023 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-micronaut {
-    importMicronautPlatform = true
-    testRuntime 'spock2'
-    processing {
-        incremental false
-    }
-}
-
 dependencies {
     api 'io.micronaut:micronaut-aop'
+
     testImplementation 'io.micronaut:micronaut-retry'
 }

--- a/libs/micronaut-rethrow/src/main/java/com/agorapulse/micronaut/rethrow/RethrowInterceptor.java
+++ b/libs/micronaut-rethrow/src/main/java/com/agorapulse/micronaut/rethrow/RethrowInterceptor.java
@@ -44,14 +44,15 @@ public class RethrowInterceptor implements MethodInterceptor<Object, Object> {
             return context.proceed();
         } catch (Throwable error) {
             AnnotationValue<Rethrow> annotation = context.getAnnotation(Rethrow.class);
+            Rethrow rethrow = readAnnotation(context);
 
-            Class<? extends Throwable>[] only = (Class<? extends Throwable>[]) annotation.get("only", Class[].class).orElse(new Class[0]);
+            Class<? extends Throwable>[] only = rethrow.only();
 
             if (only.length > 0 && only[0] != null && Arrays.stream(only).noneMatch(type -> type.isAssignableFrom(error.getClass()))) {
                 throw error;
             }
 
-            Class<? extends Function<? extends Throwable, ? extends RuntimeException>> value = readClosureAwareValue(context);
+            Class<? extends Function<? extends Throwable, ? extends RuntimeException>> value = rethrow.value();
 
             if (value != null) {
                 if ("groovy.lang.Closure".equals(value.getSuperclass().getName())) {
@@ -93,17 +94,27 @@ public class RethrowInterceptor implements MethodInterceptor<Object, Object> {
     }
 
     /**
-     * Due the ongoing bug in Micronaut we need to use the old-fashioned way to get the annotation value.
-     * @link https://github.com/micronaut-projects/micronaut-core/issues/1022
+     * Reads the {@link Rethrow} annotation via reflection rather than via
+     * Micronaut's {@link AnnotationValue} accessor.
+     *
+     * Historical reason (https://github.com/micronaut-projects/micronaut-core/issues/1022):
+     * {@link AnnotationValue#get} does not preserve the Groovy {@code Closure}
+     * subtype for the {@code value} attribute.
+     *
+     * Reason added in Micronaut 5: {@link AnnotationValue#get} now also drops the
+     * user-supplied {@code Class[]} value for the {@code only} attribute, returning
+     * an empty array (or the {@code Throwable.class} default) instead of the
+     * actual classes the annotation declares — breaking the
+     * {@code @Rethrow(only = ...)} filter.
      */
-    private Class<? extends Function<? extends Throwable, ? extends RuntimeException>> readClosureAwareValue(MethodInvocationContext<Object, Object> context) {
+    private Rethrow readAnnotation(MethodInvocationContext<Object, Object> context) {
         Rethrow rethrow = context.getTargetMethod().getAnnotation(Rethrow.class);
 
         if (rethrow == null) {
             rethrow = context.getTargetMethod().getDeclaringClass().getAnnotation(Rethrow.class);
         }
 
-        return rethrow.value();
+        return rethrow;
     }
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,9 +44,16 @@ buildscript {
 }
 
 plugins {
-    id 'com.agorapulse.gradle.settings'             version "${agorapulseGradlePluginsVersion}"
-    id 'com.agorapulse.gradle.gradle-enterprise'    version "${agorapulseGradlePluginsVersion}"
-    id 'com.agorapulse.gradle.remote-cache'         version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.settings' version "${agorapulseGradlePluginsVersion}"
+    id 'com.gradle.develocity'          version "${develocityPluginVersion}"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { true }
+    }
 }
 
 gradleProjects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ pluginManagement {
         id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+        id 'com.vanniktech.maven.publish'                      version "${mavenCentralPublishPluginVersion}"
     }
 }
 
@@ -38,6 +39,7 @@ buildscript {
         classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
         classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
         classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
+        classpath group: 'com.vanniktech',        name: 'gradle-maven-publish-plugin',  version: mavenCentralPublishPluginVersion
     }
 }
 
@@ -55,6 +57,7 @@ gradleProjects {
             id 'groovy'
             id 'com.agorapulse.gradle.micronaut-library'
             id 'com.agorapulse.gradle.groovy-common-configuration'
+            id 'com.vanniktech.maven.publish'
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2023 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,50 +15,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
+    }
+    plugins {
+        id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+    }
+}
+
 buildscript {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
     }
     dependencies {
-        classpath group: 'org.kordamp.gradle',          name: 'settings-gradle-plugin',         version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'groovy-project-gradle-plugin',   version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'checkstyle-gradle-plugin',       version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'codenarc-gradle-plugin',         version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'guide-gradle-plugin',            version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'coveralls-gradle-plugin',        version: kordampPluginVersion
-        classpath group: 'org.ajoberstar',              name: 'gradle-git-publish',             version: gitPublishPluginVersion
-        classpath group: 'io.github.gradle-nexus',      name: 'publish-plugin',                 version: nexusPluginVersion
-        classpath group: 'io.micronaut.gradle',         name: 'micronaut-minimal-plugin',       version: micronautGradlePluginVersion
+        classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
+        classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
+        classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
     }
 }
 
 plugins {
-    id 'org.kordamp.gradle.settings' version "$kordampPluginVersion"
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.agorapulse.gradle.settings'             version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.gradle-enterprise'    version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.remote-cache'         version "${agorapulseGradlePluginsVersion}"
 }
 
-gradleEnterprise {
-    buildScan {
-        publishAlways()
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+gradleProjects {
+    directories = ['libs', 'docs']
+
+    plugins {
+        dirs(['libs']) {
+            id 'groovy'
+            id 'com.agorapulse.gradle.micronaut-library'
+            id 'com.agorapulse.gradle.groovy-common-configuration'
+        }
     }
 }
 
 rootProject.name = 'micronaut-rethrow-root'
-
-projects {
-    directories = ['libs', 'docs']
-
-    plugins {
-        dir('docs') {
-            id 'org.kordamp.gradle.guide'
-            id 'org.ajoberstar.git-publish'
-        }
-        dirs(['libs']) {
-            id 'io.micronaut.minimal.library'
-            id 'groovy'
-        }
-    }
-}


### PR DESCRIPTION
## Micronaut 5.x upgrade

Brings `micronaut-rethrow` to the Micronaut Framework 5.0 baseline (Java 25, Gradle 9.5, Groovy 5, Spock 2.4-groovy-5.0).

## What changed

### Build
- Bumped `micronautVersion` and the Micronaut Gradle plugin to `5.0.0`.
- Gradle wrapper bumped to `9.5.0`; Java toolchain pinned to 25 via `javaVersion=25`.
- Replaced the Kordamp Gradle plugins (`org.kordamp.gradle.*` — unmaintained since 0.54.0 in 2022 and incompatible with Gradle 9.5) with `com.agorapulse.gradle.*` convention plugins (`settings`, `micronaut-library`, `groovy-common-configuration`, `micronaut-compatibility`, `guide`).
- Switched build-scan publishing to the public Develocity (`com.gradle.develocity` → `gradle.com`).
- Dropped per-library aggregate-test/jacoco-report tasks — the Develocity scan now aggregates everything.
- Enabled the local Gradle build cache.

### Publishing
- Replaced `io.github.gradle-nexus.publish-plugin` (legacy OSSRH `s01.oss.sonatype.org`, being deprecated by Sonatype) with `com.vanniktech.maven.publish` 0.34.0 publishing through the new Central Portal.
- Centralised the `mavenPublishing { publishToMavenCentral(true); signAllPublications(); pom { … } }` + `signing { useInMemoryPgpKeys(…) }` block in the root build so the subproject build file collapses back to just its dependencies.
- Release workflow task simplified from `publishToSonatype` + `closeAndReleaseSonatypeStagingRepository` to the single `publishAndReleaseToMavenCentral`. Credentials are now passed as the standard `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` Gradle properties.

### Release workflow
- Modernised actions: `actions/checkout@v4`, `actions/setup-java@v4` (Java 25, Zulu), `gradle/actions/setup-gradle@v5` instead of the deprecated `gradle/gradle-command-action@v2`.
- The downstream `ping` job is now gated on `!github.event.release.prerelease` so RC / SNAPSHOT releases don't notify consumers.
- Marks the artifact as Micronaut 5–compatible in the downstream notification payload.

### Source
- `RethrowInterceptor` now reads the full `@Rethrow` annotation via reflection. Micronaut 5's annotation-metadata pipeline no longer round-trips the user-supplied `Class[]` for the `only` attribute (same family of bug as the long-standing `value` issue this class already worked around). Without the fix, `@Rethrow(only = …)` silently degrades to wrapping every exception.

## Required repository secrets

- `MAVEN_CENTRAL_USERNAME`
- `MAVEN_CENTRAL_PASSWORD`

Old `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` are no longer referenced and can be removed after the first verified release.

## Test plan
- [ ] CI `Check` workflow is green on Java 25
- [ ] Publishing a pre-release tag does not trigger the downstream `ping` job
- [ ] Publishing a stable tag pings `agorapulse-bom` and `agorapulse-oss`