### PR TITLE
Configure git identity for gitPublishCommit on release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
       - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Release
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}


### PR DESCRIPTION
The release workflow's `:guide:gitPublishPush` step shells out to `git commit` to record the generated guide before pushing to `gh-pages`. On a fresh CI runner there is no global `user.name` / `user.email`, so the commit fails:

```
fatal: empty ident name (for <runner@…>) not allowed
```

(The existing `-Dorg.ajoberstar.grgit.auth.username=…` system property carries the push credential, not the commit identity — so it doesn't help here.)

Adds a step that runs `git config --global user.name / user.email` immediately before the Release step.

## Test plan
- [ ] Re-trigger the release; `:guide:gitPublishCommit` no longer fails