### PR TITLE
Provide HTTPS credentials for gitPublishPush

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,14 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: |
           ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
             -Pversion=${{ steps.version.outputs.tag }} \
             -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
             -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
             -Prelease=true \
-            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }} \
             --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -19,6 +19,14 @@ plugins {
     id 'com.agorapulse.gradle.guide'
 }
 
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
+}
+
 asciidoctor {
     baseDirFollowsSourceDir()
 


### PR DESCRIPTION
Follow-up to the earlier identity fix. `:guide:gitPublishPush` ends up calling the system `git` binary for the push to `gh-pages`, which then fails because no HTTPS credentials are available:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

The previous `-Dorg.ajoberstar.grgit.auth.username=…` system property only applies when the plugin uses jgit/grgit for the transport; on Gradle 9 the plugin falls back to system git for the push, so that property is a no-op.

This switches to the standard `git config --global url."<token-url>".insteadOf "https://github.com/"` pattern so any HTTPS GitHub push the runner makes is rewritten to a token-authenticated URL. Combined with the user.name / user.email already configured by PR #15, this makes both `gitPublishCommit` and `gitPublishPush` succeed.

Also drops the now-redundant `-Dorg.ajoberstar.grgit.auth.username=…` flag.

## Test plan
- [ ] Re-publish `3.0.0.RC1`; `:guide:gitPublishPush` completes and the gh-pages branch is updated